### PR TITLE
Update exported Cargo fields

### DIFF
--- a/scripts/export_cargo.py
+++ b/scripts/export_cargo.py
@@ -41,7 +41,7 @@ TABLE_FIELDS = {
     "Company": ["_pageName=PageName", "_pageID=PageID", "Description", "Industry", "ParentCompany", "Type", "Website" ],
     "Incident": ["_pageName=PageName", "_pageID=PageID", "Company", "StartDate", "EndDate", "Status", "ProductLine", "Product", "Type", "Description" ],
     "Product": ["_pageName=PageName", "_pageID=PageID", "Category", "Company", "Description", "ProductLine", "Website"],
-    "ProductLine": [ "_pageName=PageName", "_pageID=PageID", "Category","Company", "Description", "Website"],
+    "ProductLine": [ "_pageName=PageName", "_pageID=PageID", "Category", "Company", "Description", "Website"],
 }
 
 PAGE_SIZE = 500  # Max limit per MediaWiki request


### PR DESCRIPTION
Also includes removing the print on `logintoken`. Not sure how long those last - hopefully really short lived but we probably shouldn't be logging them just in case.